### PR TITLE
fix github CI workflows failing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - name: Set up QEMU
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}


### PR DESCRIPTION
Currently the automatic builds of this website seem to fail:
![image](https://github.com/user-attachments/assets/e616671e-640b-46c6-9aa2-dd473cda36a8)


According to this community post this change should fix it: https://github.com/orgs/community/discussions/154158

See also: https://github.com/actions/cache/discussions/1510