### PR TITLE
Update 'footer'-date.

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,9 @@
 <footer class="sans-serif pv4 ph3 mid-gray mw8 center">
     <div class="dt w-100">
-        <div class="dtr dtc-l f6 tc tl-l mb4 mb0-l">© 2024 Technische Hochschule Ingolstadt</div>
+        <div class="dtr dtc-l f6 tc tl-l mb4 mb0-l">
+            <span class="db">Last update {{ time.Now | time.Format "January 2, 2006" }}</span>
+            <span class="db">Technische Hochschule Ingolstadt</span>
+        </div>
         <div class="dtr dtc-l tr-l tc">
             <a href="https://www.thi.de/sonstiges/impressum/" class="f6 link mid-gray dim tl">Imprint</a>
         </div>


### PR DESCRIPTION
The footer date is currently expired ("Copyright 2024"). IMO, we should just put the

time of last update there, so people can decide for themselves if the info is still

relevant.



Signed-off-by: Dominik Bayerl [dominik.bayerl@carissma.eu](mailto:dominik.bayerl@carissma.eu)

