### PR TITLE
Fix build warnings

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,8 +1,7 @@
 baseURL = "https://security.science/"
-languageCode = "en-us"
+locale = "en-us"
 title = "THI Cybersecurity Research Group"
-disableKinds = [ "taxonomy" ]
-ignoreErrors = ["error-disable-taxonomy"]
+disableKinds = [ "taxonomy", "section" ]
 theme = [ "hugo-snap-gallery", "hugo-cloak-email" ]
 
 [security]


### PR DESCRIPTION
This PR fixes build errors due to deprecated config keys
and unused page layouts.

Signed-off-by: Dominik Bayerl <dominik.bayerl@carissma.eu>
